### PR TITLE
Corvus CF Part Relocation

### DIFF
--- a/GameData/CSITechTree/Mod Support/Corvus.cfg
+++ b/GameData/CSITechTree/Mod Support/Corvus.cfg
@@ -1,0 +1,32 @@
+//Corvus Command Pod
+// https://spacedock.info/mod/1405/Corvus%20CF
+
+@PART[Corvus_Exterior]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = commandModules
+}
+
+@PART[Corvus_Nose]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = enhancedSurvivability
+}
+
+@PART[Corvus_Heatshield]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = enhancedSurvivability
+}
+
+@PART[Corvus_Nose]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = enhancedSurvivability
+}
+
+@PART[Corvus_Decoupler]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = generalConstruction
+}
+
+@PART[Corvus_1875Adapter]:NEEDS[CommunityTechTree,Corvus]:BEFORE[zzzCSITechTree]
+{
+		@TechRequired = generalConstruction
+}

--- a/GameData/CSITechTree/Mod Support/MechJeb.cfg
+++ b/GameData/CSITechTree/Mod Support/MechJeb.cfg
@@ -1,5 +1,5 @@
   
-@PART[*]:HAS[@MODULE[MechJebCore],!MODULE[KerbalEVA]]:AFTER[zzzCSITechTree]
+@PART[*]:HAS[@MODULE[MechJebCore],!MODULE[KerbalEVA]]:NEEDS[!MechJebUnlocked]:AFTER[zzzCSITechTree]
 {
   %MODULE[MechJebCore]
   {


### PR DESCRIPTION
In CSITechTree the Corvus pod comes even before the Mk1. This moves it in between the Mk1 and Mk1-25 in 'Command Modules".