### PR TITLE
Update zzzRemovedNodes.cfg

### DIFF
--- a/GameData/CSITechTree/Mod Support/zzzRemovedNodes.cfg
+++ b/GameData/CSITechTree/Mod Support/zzzRemovedNodes.cfg
@@ -1,38 +1,38 @@
 // Some nodes have been removed from the tech tree
 // This moves any parts that may use them to other nodes
 @PART[*]:HAS[#TechRequired[efficientFlightSystems]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
-	{
-		@TechRequired = supersonicFlight	
-	}
+{
+ %TechRequired = supersonicFlight	
+}
 @PART[*]:HAS[#TechRequired[specializedFlightSystems]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = expAircraftEngines
+ %TechRequired = expAircraftEngines
 }
 @PART[*]:HAS[#TechRequired[automation]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = advUnmanned
+ %TechRequired = advUnmanned
 }
 @PART[*]:HAS[#TechRequired[experimentalMotors]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = mechatronics
+ %TechRequired = mechatronics
 }
 @PART[*]:HAS[#TechRequired[miniaturization]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = spaceExploration
+ %TechRequired = spaceExploration
 }
 @PART[*]:HAS[#TechRequired[precisionEngineering]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = advExploration
+ %TechRequired = advExploration
 }
 @PART[*]:HAS[#TechRequired[electronics]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = scienceTech
+ %TechRequired = scienceTech
 }
 @PART[*]:HAS[#TechRequired[fieldScience]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = advScienceTech
+ %TechRequired = advScienceTech
 }
 @PART[*]:HAS[#TechRequired[specializedScienceTech]]:NEEDS[CommunityTechTree]:LAST[zzzCSITechTree]
 {
- TechRequired = experimentalScience
+ %TechRequired = experimentalScience
 }


### PR DESCRIPTION
The way this file was previously set up meant extra entries were being made for mod parts not dealt with by any of the other configs in this directory. Since this mod already uses Module Manager syntax, we might as well use % to prevent duplicate records. What this does is that it either edits an existing entry, or creates an entry if it did not already exist. This prevents the mod from making duplicates.